### PR TITLE
F OpenNebula/one-infra#178: Remove ONEGATE_ENABLE input

### DIFF
--- a/appliances/apps/1318e7ca-bd6d-11eb-9ae8-98fa9bde1a93.yaml
+++ b/appliances/apps/1318e7ca-bd6d-11eb-9ae8-98fa9bde1a93.yaml
@@ -22,10 +22,9 @@ description: |-
   * `ONEAPP_K8S_LOADBALANCER_RANGE` - LoadBalancer IP range (default none)
   * `ONEAPP_K8S_LOADBALANCER_CONFIG` - Custom LoadBalancer config (encoded in BASE64)
 
-  **WARNING: For multi-node deployment managed by OneFlow, it's necessary
-  to set `ONEGATE_ENABLE='YES'` to enable an exchange of the connection
-  parameters among the nodes via OneGate, and report when the nodes are
-  ready to use.**
+  **WARNING: For multi-node deployment managed by OneFlow, it's necessary to add
+  the OneGate Token to the VM (with `TOKEN=YES`) and enable reporting of the ready
+  state (`REPORT_READY=YES`).**
 
   The appliance was [certified](https://landscape.cncf.io/selected=open-nebula-kubernetes-appliance) as part of [Certified Kubernetes Conformance Program](https://www.cncf.io/certification/software-conformance/):
 
@@ -57,22 +56,18 @@ opennebula_template:
     oneapp_k8s_admin_username: "$ONEAPP_K8S_ADMIN_USERNAME"
     oneapp_k8s_loadbalancer_range: "$ONEAPP_K8S_LOADBALANCER_RANGE"
     oneapp_k8s_loadbalancer_config: "$ONEAPP_K8S_LOADBALANCER_CONFIG"
-    report_ready: "$ONEGATE_ENABLE"
     ssh_public_key: "$USER[SSH_PUBLIC_KEY]"
-    token: "$ONEGATE_ENABLE"
   cpu: '2'
   vcpu: '2'
   graphics:
     listen: 0.0.0.0
     type: vnc
   inputs_order: >-
-    ONEGATE_ENABLE,ONEAPP_K8S_ADDRESS,ONEAPP_K8S_TOKEN,ONEAPP_K8S_HASH,ONEAPP_K8S_NODENAME,ONEAPP_K8S_PORT,ONEAPP_K8S_TAINTED_MASTER,ONEAPP_K8S_PODS_NETWORK,ONEAPP_K8S_ADMIN_USERNAME,ONEAPP_K8S_LOADBALANCER_RANGE,ONEAPP_K8S_LOADBALANCER_CONFIG
+    ONEAPP_K8S_ADDRESS,ONEAPP_K8S_TOKEN,ONEAPP_K8S_HASH,ONEAPP_K8S_NODENAME,ONEAPP_K8S_PORT,ONEAPP_K8S_TAINTED_MASTER,ONEAPP_K8S_PODS_NETWORK,ONEAPP_K8S_ADMIN_USERNAME,ONEAPP_K8S_LOADBALANCER_RANGE,ONEAPP_K8S_LOADBALANCER_CONFIG
   memory: '3072'
   os:
     arch: x86_64
   user_inputs:
-    onegate_enable: M|boolean|Enable OneGate reporting? (req. for multi-node)|
-      |NO
     oneapp_k8s_address: O|text|Master node address
     oneapp_k8s_token: O|password|Secret token (to join node into the cluster)
     oneapp_k8s_hash: O|text|Secret hash (to join node into the cluster)

--- a/appliances/apps/319d21ea-1a39-4c28-bc36-5ac86a966a48.yaml
+++ b/appliances/apps/319d21ea-1a39-4c28-bc36-5ac86a966a48.yaml
@@ -25,10 +25,9 @@ description: |-
   * `ONEAPP_K8S_LOADBALANCER_RANGE` - MetalLB IP range (default none)
   * `ONEAPP_K8S_LOADBALANCER_CONFIG` - Custom MetalLB config (encoded in BASE64)
 
-  **WARNING: For multi-node deployment managed by OneFlow, it's necessary
-  to set `ONEGATE_ENABLE='YES'` to enable an exchange of the connection
-  parameters among the nodes via OneGate, and report when the nodes are
-  ready to use.**
+  **WARNING: For multi-node deployment managed by OneFlow, it's necessary to add
+  the OneGate Token to the VM (with `TOKEN=YES`) and enable reporting of the ready
+  state (`REPORT_READY=YES`).**
 
 short_description: Appliance with preinstalled K3S for KVM hosts
 tags:
@@ -59,22 +58,18 @@ opennebula_template:
     oneapp_k8s_loadbalancer: "$ONEAPP_K8S_LOADBALANCER"
     oneapp_k8s_loadbalancer_range: "$ONEAPP_K8S_LOADBALANCER_RANGE"
     oneapp_k8s_loadbalancer_config: "$ONEAPP_K8S_LOADBALANCER_CONFIG"
-    report_ready: "$ONEGATE_ENABLE"
     ssh_public_key: "$USER[SSH_PUBLIC_KEY]"
-    token: "$ONEGATE_ENABLE"
   cpu: '1'
   vcpu: '2'
   graphics:
     listen: 0.0.0.0
     type: vnc
   inputs_order: >-
-    ONEGATE_ENABLE,ONEAPP_K8S_OVERRIDE_VERSION,ONEAPP_K8S_ADDRESS,ONEAPP_K8S_TOKEN,ONEAPP_K8S_NODENAME,ONEAPP_K8S_PORT,ONEAPP_K8S_TAINTED_MASTER,ONEAPP_K8S_CNI,ONEAPP_K8S_FLANNEL_BACKEND,ONEAPP_K8S_PODS_NETWORK,ONEAPP_K8S_SERVICE_NETWORK,ONEAPP_K8S_SERVICE_DNS,ONEAPP_K8S_LOADBALANCER,ONEAPP_K8S_LOADBALANCER_RANGE,ONEAPP_K8S_LOADBALANCER_CONFIG
+    ONEAPP_K8S_OVERRIDE_VERSION,ONEAPP_K8S_ADDRESS,ONEAPP_K8S_TOKEN,ONEAPP_K8S_NODENAME,ONEAPP_K8S_PORT,ONEAPP_K8S_TAINTED_MASTER,ONEAPP_K8S_CNI,ONEAPP_K8S_FLANNEL_BACKEND,ONEAPP_K8S_PODS_NETWORK,ONEAPP_K8S_SERVICE_NETWORK,ONEAPP_K8S_SERVICE_DNS,ONEAPP_K8S_LOADBALANCER,ONEAPP_K8S_LOADBALANCER_RANGE,ONEAPP_K8S_LOADBALANCER_CONFIG
   memory: '2048'
   os:
     arch: x86_64
   user_inputs:
-    onegate_enable: M|boolean|Enable OneGate reporting? (req. for multi-node)|
-      |NO
     oneapp_k8s_override_version: O|text|Custom K3s version (to override preinstalled)
     oneapp_k8s_address: O|text|Master node address
     oneapp_k8s_token: O|password|Secret token (to join node into the cluster)

--- a/appliances/apps/547ecdff-f392-43b9-abc9-5f10a9fa7aff.yaml
+++ b/appliances/apps/547ecdff-f392-43b9-abc9-5f10a9fa7aff.yaml
@@ -22,10 +22,9 @@ description: |-
   * `ONEAPP_K8S_LOADBALANCER_RANGE` - LoadBalancer IP range (default none)
   * `ONEAPP_K8S_LOADBALANCER_CONFIG` - Custom LoadBalancer config (encoded in BASE64)
 
-  **WARNING: For multi-node deployment managed by OneFlow, it's necessary
-  to set `ONEGATE_ENABLE='YES'` to enable an exchange of the connection
-  parameters among the nodes via OneGate, and report when the nodes are
-  ready to use.**
+  **WARNING: For multi-node deployment managed by OneFlow, it's necessary to add
+  the OneGate Token to the VM (with `TOKEN=YES`) and enable reporting of the ready
+  state (`REPORT_READY=YES`).**
 
   The appliance was [certified](https://landscape.cncf.io/selected=open-nebula-kubernetes-appliance) as part of [Certified Kubernetes Conformance Program](https://www.cncf.io/certification/software-conformance/):
 
@@ -57,22 +56,18 @@ opennebula_template:
     oneapp_k8s_admin_username: "$ONEAPP_K8S_ADMIN_USERNAME"
     oneapp_k8s_loadbalancer_range: "$ONEAPP_K8S_LOADBALANCER_RANGE"
     oneapp_k8s_loadbalancer_config: "$ONEAPP_K8S_LOADBALANCER_CONFIG"
-    report_ready: "$ONEGATE_ENABLE"
     ssh_public_key: "$USER[SSH_PUBLIC_KEY]"
-    token: "$ONEGATE_ENABLE"
   cpu: '2'
   vcpu: '2'
   graphics:
     listen: 0.0.0.0
     type: vnc
   inputs_order: >-
-    ONEGATE_ENABLE,ONEAPP_K8S_ADDRESS,ONEAPP_K8S_TOKEN,ONEAPP_K8S_HASH,ONEAPP_K8S_NODENAME,ONEAPP_K8S_PORT,ONEAPP_K8S_TAINTED_MASTER,ONEAPP_K8S_PODS_NETWORK,ONEAPP_K8S_ADMIN_USERNAME,ONEAPP_K8S_LOADBALANCER_RANGE,ONEAPP_K8S_LOADBALANCER_CONFIG
+    ONEAPP_K8S_ADDRESS,ONEAPP_K8S_TOKEN,ONEAPP_K8S_HASH,ONEAPP_K8S_NODENAME,ONEAPP_K8S_PORT,ONEAPP_K8S_TAINTED_MASTER,ONEAPP_K8S_PODS_NETWORK,ONEAPP_K8S_ADMIN_USERNAME,ONEAPP_K8S_LOADBALANCER_RANGE,ONEAPP_K8S_LOADBALANCER_CONFIG
   memory: '3072'
   os:
     arch: x86_64
   user_inputs:
-    onegate_enable: M|boolean|Enable OneGate reporting? (req. for multi-node)|
-      |NO
     oneapp_k8s_address: O|text|Master node address/network (CIDR subnet)
     oneapp_k8s_token: O|password|Secret token (to join node into the cluster)
     oneapp_k8s_hash: O|text|Secret hash (to join node into the cluster)

--- a/appliances/flow/1486f503-e065-4f86-8b49-618d892e167e.yaml
+++ b/appliances/flow/1486f503-e065-4f86-8b49-618d892e167e.yaml
@@ -32,14 +32,14 @@ opennebula_template: '{
     {
       "name": "master",
       "cardinality": 1,
-      "vm_template_contents": "ONEGATE_ENABLE=\"YES\"\nNIC=[NAME=\"NIC0\",NETWORK_ID=\"$Public\"]\n",
+      "vm_template_contents": "REPORT_READY=\"YES\"\nTOKEN=\"YES\"\nNIC=[NAME=\"NIC0\",NETWORK_ID=\"$Public\"]\n",
       "elasticity_policies": [],
       "scheduled_policies": []
     },
     {
       "name": "worker",
       "cardinality": 1,
-      "vm_template_contents": "ONEGATE_ENABLE=\"YES\"\nNIC=[NAME=\"NIC0\",NETWORK_ID=\"$Public\"]\n",
+      "vm_template_contents": "REPORT_READY=\"YES\"\nTOKEN=\"YES\"\nNIC=[NAME=\"NIC0\",NETWORK_ID=\"$Public\"]\n",
       "parents": [
         "master"
       ],

--- a/appliances/flow/aeb3dc2d-b0ba-4aed-ae87-3122e93edb65.yaml
+++ b/appliances/flow/aeb3dc2d-b0ba-4aed-ae87-3122e93edb65.yaml
@@ -29,14 +29,14 @@ opennebula_template: '{
     {
       "name": "master",
       "cardinality": 1,
-      "vm_template_contents": "ONEGATE_ENABLE=\"YES\"\nNIC=[NAME=\"NIC0\",NETWORK_ID=\"$Public\"]\n",
+      "vm_template_contents": "REPORT_READY=\"YES\"\nTOKEN=\"YES\"\nNIC=[NAME=\"NIC0\",NETWORK_ID=\"$Public\"]\n",
       "elasticity_policies": [],
       "scheduled_policies": []
     },
     {
       "name": "worker",
       "cardinality": 1,
-      "vm_template_contents": "ONEGATE_ENABLE=\"YES\"\nNIC=[NAME=\"NIC0\",NETWORK_ID=\"$Public\"]\n",
+      "vm_template_contents": "REPORT_READY=\"YES\"\nTOKEN=\"YES\"\nNIC=[NAME=\"NIC0\",NETWORK_ID=\"$Public\"]\n",
       "parents": [
         "master"
       ],

--- a/appliances/flow/dd6ed430-bd6d-11eb-9e90-98fa9bde1a93.yaml
+++ b/appliances/flow/dd6ed430-bd6d-11eb-9e90-98fa9bde1a93.yaml
@@ -32,14 +32,14 @@ opennebula_template: '{
     {
       "name": "master",
       "cardinality": 1,
-      "vm_template_contents": "ONEGATE_ENABLE=\"YES\"\nNIC=[NAME=\"NIC0\",NETWORK_ID=\"$Public\"]\n",
+      "vm_template_contents": "REPORT_READY=\"YES\"\nTOKEN=\"YES\"\nNIC=[NAME=\"NIC0\",NETWORK_ID=\"$Public\"]\n",
       "elasticity_policies": [],
       "scheduled_policies": []
     },
     {
       "name": "worker",
       "cardinality": 1,
-      "vm_template_contents": "ONEGATE_ENABLE=\"YES\"\nNIC=[NAME=\"NIC0\",NETWORK_ID=\"$Public\"]\n",
+      "vm_template_contents": "REPORT_READY=\"YES\"\nTOKEN=\"YES\"\nNIC=[NAME=\"NIC0\",NETWORK_ID=\"$Public\"]\n",
       "parents": [
         "master"
       ],


### PR DESCRIPTION
The user input `ONEGATE_ENABLE` was used as a crutch in the template to
setup both the `TOKEN` and `REPORT_READY` to `YES` in a convenient way.

The issue is that if the template is not left in the default state then
the following content could be erased:
```
  REPORT_READY = "$ONEGATE_ENABLE",
  TOKEN = "$ONEGATE_ENABLE"
```

And `ONEGATE_ENABLE` would be rendered defunct - which may confuse the
user: why the behavior of the `ONEGATE_ENABLE` input does not work
anymore.

This can happen when 'Add OneGate Token' or 'Report Ready to OneGate' is
changed in the Sunstone and the original template workaround with
`ONEGATE_ENABLE` is broken:
```
  ONEGATE_ENABLE = "$ONEGATE_ENABLE",
  REPORT_READY = "YES",
  TOKEN = "YES"
```

The VM template is left with disabled OneGate by default (as is with the
all other appliances) but it is enabled be default for the Service
Template - where OneGate is needed for it to work properly in OneFlow
scenario.

Signed-off-by: Petr Ospalý <pospaly@opennebula.io>