### PR TITLE
M #-: Refresh K8s and K3s appliances

### DIFF
--- a/appliances/apps/1318e7ca-bd6d-11eb-9ae8-98fa9bde1a93.yaml
+++ b/appliances/apps/1318e7ca-bd6d-11eb-9ae8-98fa9bde1a93.yaml
@@ -1,6 +1,6 @@
 ---
 name: Kubernetes 1.21 - KVM
-version: 1.21.5-6.2.0-1.20211028
+version: 1.21.9-6.2.0-1.20220217
 publisher: OpenNebula Systems
 description: |-
   Appliance with preinstalled Kubernetes to work as a single-node cluster,
@@ -12,7 +12,7 @@ description: |-
 
   Initial configuration can be customized via parameters:
 
-  * `ONEAPP_K8S_ADDRESS` - K8s master node address
+  * `ONEAPP_K8S_ADDRESS` - K8s master node address/network (CIDR subnet)
   * `ONEAPP_K8S_TOKEN` - K8s token (to join node into the cluster)
   * `ONEAPP_K8S_HASH` - K8s hash (to join node into the cluster)
   * `ONEAPP_K8S_NODENAME` - K8s master node name
@@ -68,7 +68,7 @@ opennebula_template:
   os:
     arch: x86_64
   user_inputs:
-    oneapp_k8s_address: O|text|Master node address
+    oneapp_k8s_address: O|text|Master node address/network (CIDR subnet)
     oneapp_k8s_token: O|password|Secret token (to join node into the cluster)
     oneapp_k8s_hash: O|text|Secret hash (to join node into the cluster)
     oneapp_k8s_nodename: O|text|Master node name
@@ -85,11 +85,11 @@ logo: kubernetes.png
 images:
 - name: kubernetes
   url: >-
-    https://d24fmfybwxpuhu.cloudfront.net/service_kubernetes-1.21.5-6.2.0-1.20211022.qcow2
+    https://d24fmfybwxpuhu.cloudfront.net/service_kubernetes-1.21.9-6.2.0-1.20220217.qcow2
   type: OS
   dev_prefix: vd
   driver: qcow2
   size: 5368709120
   checksum:
-    md5: bbbcfdd5e986cabad9a80edbd7b4891c
-    sha256: f1943dfb409789dc07a254a1c62df26a4e30afdc6c9b826563605e23505101d7
+    md5: 9c28c7f10584691abc5d3fd51050b5de
+    sha256: 8523a93c3ade47df71b3513a3e30d69668f3a814b228e44c2655c53e4f835fb1

--- a/appliances/apps/319d21ea-1a39-4c28-bc36-5ac86a966a48.yaml
+++ b/appliances/apps/319d21ea-1a39-4c28-bc36-5ac86a966a48.yaml
@@ -1,6 +1,6 @@
 ---
 name: K3s 1.21.5+k3s2 - KVM
-version: 1.21.5-6.2.0-1.20211029
+version: 1.21.5-6.2.0-1.20220217
 publisher: OpenNebula Systems
 description: |-
   Appliance with preinstalled K3s to work as a single-node cluster,
@@ -14,7 +14,7 @@ description: |-
   Initial configuration can be customized via parameters:
 
   * `ONEAPP_K8S_OVERRIDE_VERSION` - Custom K3s version (to override preinstalled)
-  * `ONEAPP_K8S_ADDRESS` - K3s master node address
+  * `ONEAPP_K8S_ADDRESS` - K3s master node address/network (CIDR subnet)
   * `ONEAPP_K8S_TOKEN` - K3s token (to join node into the cluster)
   * `ONEAPP_K8S_NODENAME` - K3s master node name
   * `ONEAPP_K8S_PORT` - K3s API port (default 6443)
@@ -28,7 +28,6 @@ description: |-
   **WARNING: For multi-node deployment managed by OneFlow, it's necessary to add
   the OneGate Token to the VM (with `TOKEN=YES`) and enable reporting of the ready
   state (`REPORT_READY=YES`).**
-
 short_description: Appliance with preinstalled K3S for KVM hosts
 tags:
 - k3s
@@ -70,8 +69,9 @@ opennebula_template:
   os:
     arch: x86_64
   user_inputs:
-    oneapp_k8s_override_version: O|text|Custom K3s version (to override preinstalled)
-    oneapp_k8s_address: O|text|Master node address
+    oneapp_k8s_override_version: O|text|Custom K3s version (to override
+      preinstalled)
+    oneapp_k8s_address: O|text|Master node address/network (CIDR subnet)
     oneapp_k8s_token: O|password|Secret token (to join node into the cluster)
     oneapp_k8s_nodename: O|text|Master node name
     oneapp_k8s_port: O|text|Kubernetes API port (default 6443)
@@ -80,21 +80,21 @@ opennebula_template:
     oneapp_k8s_cni: O|text|Container Network Interface (default flannel)
     oneapp_k8s_flannel_backend: O|text|Flannel CNI backend (default vxlan)
     oneapp_k8s_pods_network: O|text|Pods network in CIDR (default 10.244.0.0/16)
-    oneapp_k8s_service_network: O|text|Service network in CIDR (default 10.96.0.0/12)
+    oneapp_k8s_service_network: O|text|Service network in CIDR (default
+      10.96.0.0/12)
     oneapp_k8s_service_dns: O|text|DNS in the service network (default 10.96.0.10)
     oneapp_k8s_loadbalancer: O|text|LoadBalancer provider (default servicelb)
-    oneapp_k8s_loadbalancer_range: O|text|MetalLB IP range (default
-      none)
+    oneapp_k8s_loadbalancer_range: O|text|MetalLB IP range (default none)
     oneapp_k8s_loadbalancer_config: O|text64|Custom MetalLB config
 logo: k3s.png
 images:
 - name: k3s
   url: >-
-    https://d24fmfybwxpuhu.cloudfront.net/service_k3s-6.2.0-1.20211129.qcow2
+    https://d24fmfybwxpuhu.cloudfront.net/service_k3s-1.21.5-6.2.0-1.20220217.qcow2
   type: OS
   dev_prefix: vd
   driver: qcow2
-  size: 1073741824
+  size: 2147483648
   checksum:
-    md5: 3bc48d001fdf12cdfcad8a66b1060d23
-    sha256: 860073abf0dcf9ab9c20122ba634dc713bbdcfbb858097fdf3ba1a783221ff7a
+    md5: e94c420d8669ef053ec8023a20365384
+    sha256: fd1217e0b2dade517889285d21d5f68cc172121f6ab40d3f9ede955399fc6d34

--- a/appliances/apps/547ecdff-f392-43b9-abc9-5f10a9fa7aff.yaml
+++ b/appliances/apps/547ecdff-f392-43b9-abc9-5f10a9fa7aff.yaml
@@ -1,6 +1,6 @@
 ---
 name: Kubernetes 1.18 - KVM
-version: 1.18.18-6.0.0-1.20211027
+version: 1.18.20-6.2.0-1.20220217
 publisher: OpenNebula Systems
 description: |-
   Appliance with preinstalled Kubernetes to work as a single-node cluster,
@@ -85,11 +85,11 @@ logo: kubernetes.png
 images:
 - name: kubernetes
   url: >-
-    https://d24fmfybwxpuhu.cloudfront.net/service_kubernetes-1.18.18-6.0.0-1.20210505.qcow2
+    https://d24fmfybwxpuhu.cloudfront.net/service_kubernetes-1.18.20-6.2.0-1.20220217.qcow2
   type: OS
   dev_prefix: vd
   driver: qcow2
-  size: 4294967296
+  size: 5368709120
   checksum:
-    md5: a25785666cba783c0f8521bea458d75b
-    sha256: b9ee7cf5287f194f01a2cfe54fb7a43e9dc4a9f29669d0e89df9db0e66f4c752
+    md5: 347a82a7d3f6a2567d6c2939d5b567eb
+    sha256: 958886ce2c5f8dad5a003c7f7fe20a6780ff3e9502e0300eb837e606069cd50d

--- a/appliances/flow/1486f503-e065-4f86-8b49-618d892e167e.yaml
+++ b/appliances/flow/1486f503-e065-4f86-8b49-618d892e167e.yaml
@@ -1,6 +1,6 @@
 ---
 name: Service Kubernetes 1.18 - KVM
-version: 1.18.18-6.2.0-1.20211027
+version: 1.18.20-6.2.0-1.20220217
 publisher: OpenNebula Systems
 description: |-
   Multi-node Kubernetes cluster for KVM hosts based on [Service Kubernetes 1.18 - KVM](/appliance/547ecdff-f392-43b9-abc9-5f10a9fa7aff) appliance and orchestrated by [OneFlow](https://docs.opennebula.io/6.2/management_and_operations/multivm_service_management/appflow_elasticity.html). Requires OneGate and OneFlow OpenNebula services. See the dedicated [documentation](http://marketplace.opennebula.systems/docs/service/kubernetes.html).

--- a/appliances/flow/aeb3dc2d-b0ba-4aed-ae87-3122e93edb65.yaml
+++ b/appliances/flow/aeb3dc2d-b0ba-4aed-ae87-3122e93edb65.yaml
@@ -1,6 +1,6 @@
 ---
 name: Service K3s 1.21.5+k3s2 - KVM
-version: 1.21.2-6.2.0-1.20211027
+version: 1.21.5-6.2.0-1.20220217
 publisher: OpenNebula Systems
 description: |-
   Multi-node K3s cluster for KVM hosts based on [Service K3s 1.21.5+k3s2 - KVM](/appliance/319d21ea-1a39-4c28-bc36-5ac86a966a48) appliance and orchestrated by [OneFlow](https://docs.opennebula.io/6.2/management_and_operations/multivm_service_management/appflow_elasticity.html). Requires OneGate and OneFlow OpenNebula services. See the dedicated [documentation](http://marketplace.opennebula.systems/docs/service/k3s.html).

--- a/appliances/flow/dd6ed430-bd6d-11eb-9e90-98fa9bde1a93.yaml
+++ b/appliances/flow/dd6ed430-bd6d-11eb-9e90-98fa9bde1a93.yaml
@@ -1,6 +1,6 @@
 ---
 name: Service Kubernetes 1.21 - KVM
-version: 1.21.2-6.2.0-1.20211027
+version: 1.21.9-6.2.0-1.20220217
 publisher: OpenNebula Systems
 description: |-
   Multi-node Kubernetes cluster for KVM hosts based on [Service Kubernetes 1.21 - KVM](/appliance/1318e7ca-bd6d-11eb-9ae8-98fa9bde1a93) appliance and orchestrated by [OneFlow](https://docs.opennebula.io/6.2/management_and_operations/multivm_service_management/appflow_elasticity.html). Requires OneGate and OneFlow OpenNebula services. See the dedicated [documentation](http://marketplace.opennebula.systems/docs/service/kubernetes.html).


### PR DESCRIPTION
- Update images with improved OneGate integration
- Add back CIDR notation
- Bump K8s 1.21 to 1.21.9
- Bump K8s 1.18 to 1.18.20

Signed-off-by: Petr Ospalý <pospaly@opennebula.io>