### PR TITLE
M #-: VR/OneKE: DNS/SAN fixes

### DIFF
--- a/appliances/OneKE_1.27/7c82d610-73f1-47d1-a85a-d799e00c631e.yaml
+++ b/appliances/OneKE_1.27/7c82d610-73f1-47d1-a85a-d799e00c631e.yaml
@@ -1,6 +1,6 @@
 ---
 name: Service OneKE 1.27
-version: 1.27.2-6.8.1-1-20240131
+version: 1.27.2-6.8.1-1-20240213
 publisher: OpenNebula Systems
 description: |-
   [RKE2](https://docs.rke2.io/) based multi-master Kubernetes 1.27 cluster for KVM and vCenter hosts,
@@ -67,6 +67,7 @@ opennebula_template:
         ONEAPP_VNF_HAPROXY_LB3_PORT = "$ONEAPP_VNF_HAPROXY_LB3_PORT"
         ONEAPP_VNF_DNS_ENABLED = "$ONEAPP_VNF_DNS_ENABLED"
         ONEAPP_VNF_DNS_INTERFACES = "$ONEAPP_VNF_DNS_INTERFACES"
+        ONEAPP_VNF_DNS_NAMESERVERS = "$ONEAPP_VNF_DNS_NAMESERVERS"
         ONEAPP_VNF_NAT4_ENABLED = "$ONEAPP_VNF_NAT4_ENABLED"
         ONEAPP_VNF_NAT4_INTERFACES_OUT = "$ONEAPP_VNF_NAT4_INTERFACES_OUT"
         ONEAPP_VNF_ROUTER4_ENABLED = "$ONEAPP_VNF_ROUTER4_ENABLED"
@@ -167,7 +168,7 @@ opennebula_template:
     ONEAPP_VROUTER_ETH1_VIP0: "O|text|Default Gateway VIP (IPv4)||"
     ONEAPP_RKE2_SUPERVISOR_EP: "O|text|RKE2 Supervisor endpoint||ep0.eth0.vr:9345"
     ONEAPP_K8S_CONTROL_PLANE_EP: "O|text|Control Plane endpoint||ep0.eth0.vr:6443"
-    ONEAPP_K8S_EXTRA_SANS: "O|text|ApiServer extra certificate SANs||localhost,127.0.0.1,ep0.eth0.vr"
+    ONEAPP_K8S_EXTRA_SANS: "O|text|ApiServer extra certificate SANs||localhost,127.0.0.1,ep0.eth0.vr,${vnf.TEMPLATE.CONTEXT.ETH0_IP}"
     ONEAPP_K8S_MULTUS_ENABLED: "O|boolean|Enable Multus||NO"
     ONEAPP_K8S_MULTUS_CONFIG: "O|text64|Multus custom config (default none)||"
     ONEAPP_K8S_CNI_PLUGIN: "O|list|CNI plugin supported by RKE2|canal,calico,cilium|cilium"
@@ -188,6 +189,7 @@ opennebula_template:
     ONEAPP_VNF_HAPROXY_LB3_PORT: "O|number|HTTP ingress port||80"
     ONEAPP_VNF_DNS_ENABLED: "O|boolean|Enable DNS recursor||YES"
     ONEAPP_VNF_DNS_INTERFACES: "O|text|DNS - Interfaces||eth1"
+    ONEAPP_VNF_DNS_NAMESERVERS: "O|text|DNS - Nameservers||1.1.1.1,8.8.8.8"
     ONEAPP_VNF_NAT4_ENABLED: "O|boolean|Enable NAT||YES"
     ONEAPP_VNF_NAT4_INTERFACES_OUT: "O|text|NAT - Outgoing Interfaces||eth0"
     ONEAPP_VNF_ROUTER4_ENABLED: "O|boolean|Enable Router||YES"

--- a/appliances/OneKE_1.27/8285d732-0741-4623-ba9e-4eacd2421e91.yaml
+++ b/appliances/OneKE_1.27/8285d732-0741-4623-ba9e-4eacd2421e91.yaml
@@ -1,6 +1,6 @@
 ---
 name: OneKE 1.27 VNF
-version: 1.27.2-6.8.1-1-20240131
+version: 1.27.2-6.8.1-1-20240213
 publisher: OpenNebula Systems
 description: |-
   Appliance providing several Virtual Network Functions (routing, NAT, DNS, DHCP)
@@ -46,6 +46,8 @@ opennebula_template:
     oneapp_vnf_haproxy_lb3_port: "$ONEAPP_VNF_HAPROXY_LB3_PORT"
     oneapp_vnf_dns_enabled: "$ONEAPP_VNF_DNS_ENABLED"
     oneapp_vnf_dns_interfaces: "$ONEAPP_VNF_DNS_INTERFACES"
+    oneapp_vnf_dns_nameservers: "$ONEAPP_VNF_DNS_NAMESERVERS"
+    oneapp_vnf_dns_use_rootservers: 'NO'
     oneapp_vnf_nat4_enabled: "$ONEAPP_VNF_NAT4_ENABLED"
     oneapp_vnf_nat4_interfaces_out: "$ONEAPP_VNF_NAT4_INTERFACES_OUT"
     oneapp_vnf_router4_enabled: "$ONEAPP_VNF_ROUTER4_ENABLED"
@@ -66,11 +68,11 @@ logo: router.png
 images:
 - name: oneke_vnf
   url: >-
-    https://d24fmfybwxpuhu.cloudfront.net/service_VRouter-6.8.1-1-20240131.qcow2
+    https://d24fmfybwxpuhu.cloudfront.net/service_VRouter-6.8.1-1-20240213.qcow2
   type: OS
   dev_prefix: vd
   driver: qcow2
   size: 2147483648
   checksum:
-    md5: aaec08c5d33e81bd12dde55dad22609c
-    sha256: 66403685a2134ef3440ecb2cb3ecabf57aebcd703abb3c00e67fca555f21440e
+    md5: a052c7adc1185ab59a346430aa0d997d
+    sha256: 1f1d25cca546c1f8e3caca5cd1cc5fbb3f09aa6e71d172a2854cbc0e0cc6fc8d

--- a/appliances/OneKE_1.27a/6f97fe15-0d4f-4a13-9cec-1766cd2bf225.yaml
+++ b/appliances/OneKE_1.27a/6f97fe15-0d4f-4a13-9cec-1766cd2bf225.yaml
@@ -1,6 +1,6 @@
 ---
 name: Service OneKE 1.27a
-version: 1.27.2-6.8.1-1-20240131
+version: 1.27.2-6.8.1-1-20240213
 publisher: OpenNebula Systems
 description: |-
   [RKE2](https://docs.rke2.io/) based multi-master Kubernetes 1.27a cluster (**airgapped install**) for KVM and vCenter hosts,
@@ -67,6 +67,7 @@ opennebula_template:
         ONEAPP_VNF_HAPROXY_LB3_PORT = "$ONEAPP_VNF_HAPROXY_LB3_PORT"
         ONEAPP_VNF_DNS_ENABLED = "$ONEAPP_VNF_DNS_ENABLED"
         ONEAPP_VNF_DNS_INTERFACES = "$ONEAPP_VNF_DNS_INTERFACES"
+        ONEAPP_VNF_DNS_NAMESERVERS = "$ONEAPP_VNF_DNS_NAMESERVERS"
         ONEAPP_VNF_NAT4_ENABLED = "$ONEAPP_VNF_NAT4_ENABLED"
         ONEAPP_VNF_NAT4_INTERFACES_OUT = "$ONEAPP_VNF_NAT4_INTERFACES_OUT"
         ONEAPP_VNF_ROUTER4_ENABLED = "$ONEAPP_VNF_ROUTER4_ENABLED"
@@ -167,7 +168,7 @@ opennebula_template:
     ONEAPP_VROUTER_ETH1_VIP0: "O|text|Default Gateway VIP (IPv4)||"
     ONEAPP_RKE2_SUPERVISOR_EP: "O|text|RKE2 Supervisor endpoint||ep0.eth0.vr:9345"
     ONEAPP_K8S_CONTROL_PLANE_EP: "O|text|Control Plane endpoint||ep0.eth0.vr:6443"
-    ONEAPP_K8S_EXTRA_SANS: "O|text|ApiServer extra certificate SANs||localhost,127.0.0.1,ep0.eth0.vr"
+    ONEAPP_K8S_EXTRA_SANS: "O|text|ApiServer extra certificate SANs||localhost,127.0.0.1,ep0.eth0.vr,${vnf.TEMPLATE.CONTEXT.ETH0_IP}"
     ONEAPP_K8S_MULTUS_ENABLED: "O|boolean|Enable Multus||NO"
     ONEAPP_K8S_MULTUS_CONFIG: "O|text64|Multus custom config (default none)||"
     ONEAPP_K8S_CNI_PLUGIN: "O|list|CNI plugin supported by RKE2|canal,calico,cilium|cilium"
@@ -188,6 +189,7 @@ opennebula_template:
     ONEAPP_VNF_HAPROXY_LB3_PORT: "O|number|HTTP ingress port||80"
     ONEAPP_VNF_DNS_ENABLED: "O|boolean|Enable DNS recursor||YES"
     ONEAPP_VNF_DNS_INTERFACES: "O|text|DNS - Interfaces||eth1"
+    ONEAPP_VNF_DNS_NAMESERVERS: "O|text|DNS - Nameservers||1.1.1.1,8.8.8.8"
     ONEAPP_VNF_NAT4_ENABLED: "O|boolean|Enable NAT||YES"
     ONEAPP_VNF_NAT4_INTERFACES_OUT: "O|text|NAT - Outgoing Interfaces||eth0"
     ONEAPP_VNF_ROUTER4_ENABLED: "O|boolean|Enable Router||YES"

--- a/appliances/service/cc96d537-f6c7-499f-83f1-15ac4058750e.yaml
+++ b/appliances/service/cc96d537-f6c7-499f-83f1-15ac4058750e.yaml
@@ -1,6 +1,6 @@
 ---
 name: Service Virtual Router
-version: 6.8.1-1-20240131
+version: 6.8.1-1-20240213
 publisher: OpenNebula Systems
 description: |-
   Appliance providing several Virtual Network Functions (routing, NAT, DNS,
@@ -78,11 +78,11 @@ logo: router.png
 images:
 - name: service_vnf
   url: >-
-    https://d24fmfybwxpuhu.cloudfront.net/service_VRouter-6.8.1-1-20240131.qcow2
+    https://d24fmfybwxpuhu.cloudfront.net/service_VRouter-6.8.1-1-20240213.qcow2
   type: OS
   dev_prefix: vd
   driver: qcow2
   size: 2147483648
   checksum:
-    md5: aaec08c5d33e81bd12dde55dad22609c
-    sha256: 66403685a2134ef3440ecb2cb3ecabf57aebcd703abb3c00e67fca555f21440e
+    md5: a052c7adc1185ab59a346430aa0d997d
+    sha256: 1f1d25cca546c1f8e3caca5cd1cc5fbb3f09aa6e71d172a2854cbc0e0cc6fc8d


### PR DESCRIPTION
- Release corrected VR image (20240213)
- Do not use DNS rootservers in VR/OneKE
- Auto-add *first* public VR IP to OneKE's SANs