### PR TITLE
F OpenNebula/one#7227: Win virtio v0.1.285 to be used in Windows VM template

### DIFF
--- a/appliances/default/iso/1d48dcb2-12e9-4ef2-b9ba-a9b278917efb.yaml
+++ b/appliances/default/iso/1d48dcb2-12e9-4ef2-b9ba-a9b278917efb.yaml
@@ -20,5 +20,5 @@ images:
   driver: raw
   size: 789645312
   checksum:
-    md5: 9e650d0e7c6e017a91ca299c8f7ed766 
-    sha256: e14cf2b94492c3e925f0070ba7fdfedeb2048c91eea9c5a5afb30232a3976331  
+    md5: 9e650d0e7c6e017a91ca299c8f7ed766
+    sha256: e14cf2b94492c3e925f0070ba7fdfedeb2048c91eea9c5a5afb30232a3976331

--- a/appliances/default/iso/1d48dcb2-12e9-4ef2-b9ba-a9b278917efb.yaml
+++ b/appliances/default/iso/1d48dcb2-12e9-4ef2-b9ba-a9b278917efb.yaml
@@ -1,0 +1,24 @@
+---
+name: Windows VirtIO Drivers
+version: 0.1.285
+publisher: OpenNebula Systems
+description: CD-ROM image with stable VirtIO drivers for Windows.
+short_description: CD-ROM image with VirtIO drivers for Windows
+tags:
+- cdrom
+- virtio
+format: raw
+creation_time: 1758005613
+os-id: Windows
+hypervisor: KVM
+opennebula_version: 6.10, 7.0
+images:
+- name: virtio-win
+  url: https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/archive-virtio/virtio-win-0.1.285-1/virtio-win-0.1.285.iso
+  type: CDROM
+  dev_prefix: hd
+  driver: raw
+  size: 789645312
+  checksum:
+    md5: 9e650d0e7c6e017a91ca299c8f7ed766 
+    sha256: e14cf2b94492c3e925f0070ba7fdfedeb2048c91eea9c5a5afb30232a3976331  


### PR DESCRIPTION
Latest stable virtio ISO image v0.1.285 to be used in Windows VM template. The one we have in our marketplace is pretty old (dated by Sept 2023).
That image is going to be used for Windows VM template