### PR TITLE
F OpenNebula/one-apps#276: Windows VM template

### DIFF
--- a/appliances/default/all/6ea507ea-f894-423a-ad40-8c6b33c7ed60.yaml
+++ b/appliances/default/all/6ea507ea-f894-423a-ad40-8c6b33c7ed60.yaml
@@ -53,6 +53,7 @@ opennebula_template:
     virtio_blk_queues: 'auto'
     virtio_scsi_queues: 'auto'
   raw:
+    type: 'kvm'
     data: |-
       <features>
         <hyperv>

--- a/appliances/default/all/6ea507ea-f894-423a-ad40-8c6b33c7ed60.yaml
+++ b/appliances/default/all/6ea507ea-f894-423a-ad40-8c6b33c7ed60.yaml
@@ -27,7 +27,7 @@ format: qcow2
 opennebula_version: 6.0, 6.2, 6.4, 6.6, 6.8, 6.10, 7.0
 disks:
   - 'Empty disk'
-  - 'Windows VirtIO Drivers'
+  - 'Windows VirtIO Drivers - v0.1.285'
   - 'Contextualization Packages'
 opennebula_template:
   context:
@@ -43,6 +43,8 @@ opennebula_template:
   os:
     arch: x86_64
     machine: 'q35'
+    firmware: 'UEFI'
+    firmware_secure: 'Yes'
   input:
     type: 'tablet'
     bus: 'usb'

--- a/appliances/default/all/6ea507ea-f894-423a-ad40-8c6b33c7ed60.yaml
+++ b/appliances/default/all/6ea507ea-f894-423a-ad40-8c6b33c7ed60.yaml
@@ -71,11 +71,11 @@ opennebula_template:
           <vpindex state='on'/>
         </hyperv>
       </features>
-        <clock offset='utc'>
-          <timer name='hpet' present='no'/>
-          <timer name='hypervclock' present='yes'/>
-          <timer name='pit' tickpolicy='delay'/>
-          <timer name='rtc' tickpolicy='catchup'/>
-        </clock>
+      <clock offset='utc'>
+        <timer name='hpet' present='no'/>
+        <timer name='hypervclock' present='yes'/>
+        <timer name='pit' tickpolicy='delay'/>
+        <timer name='rtc' tickpolicy='catchup'/>
+      </clock>
     validate: 'Yes'
 images: []

--- a/appliances/default/all/6ea507ea-f894-423a-ad40-8c6b33c7ed60.yaml
+++ b/appliances/default/all/6ea507ea-f894-423a-ad40-8c6b33c7ed60.yaml
@@ -24,7 +24,7 @@ hypervisor: KVM
 os-id: none
 os-arch: x86_64
 format: qcow2
-opennebula_version: 6.0, 6.2, 6.4, 6.6, 6.8, 6.10, 7.0
+opennebula_version: 6.10, 7.0
 disks:
   - 'Empty disk'
   - 'Windows VirtIO Drivers - v0.1.285'

--- a/appliances/default/all/6ea507ea-f894-423a-ad40-8c6b33c7ed60.yaml
+++ b/appliances/default/all/6ea507ea-f894-423a-ad40-8c6b33c7ed60.yaml
@@ -43,6 +43,9 @@ opennebula_template:
   os:
     arch: x86_64
     machine: 'q35'
+  input:
+    type: 'tablet'
+    bus: 'usb'
   features:
     ACPI: 'Yes'
     apic: 'Yes'

--- a/appliances/default/all/6ea507ea-f894-423a-ad40-8c6b33c7ed60.yaml
+++ b/appliances/default/all/6ea507ea-f894-423a-ad40-8c6b33c7ed60.yaml
@@ -4,17 +4,19 @@ version: 7.0.0-0-20250926
 publisher: OpenNebula Systems
 description: |-
   Windows VM Template skeleton with a set of the following files and recommended settings for Windows VM:
-    - empty disk (to be used either for Windows installation or to be replaced with already pre-installed Windows OS if you already has such one,
+    - empty disk (to be used either for Windows installation or to be replaced with already pre-installed Windows OS if you already has such one),
     - virtio-win.iso (an image file containing paravirtualized drivers required for optimal performance of Windows VMs on virtualization platforms such as KVM and some other hypervisors),
-    - one-context.iso (an image file containing OpenNebula [contextualization package](https://docs.opennebula.io/stable/product/virtual_machines_operation/guest_operating_systems/kvm_contextualization/).
+    - one-context.iso (an image file containing OpenNebula [contextualization package](https://docs.opennebula.io/stable/product/virtual_machines_operation/guest_operating_systems/kvm_contextualization/)).
 
   This VM template should be imported into your OpenNebula cloud. After that depending on your requirements
   1) a Windows Installation ISO image needs to be added to that template to be used for Windows installation on the empty image or
-  2) the empty disk has to be replace with already pre-installed Windows OS disk.
+  2) the empty disk has to be replaced with one which already has pre-installed Windows OS.
 
   That VM template also contains optimal settings for Windows VMs.
 
   **Note**: Remember to update the template in order to add a network after importing it.
+
+  **Warning**: Some additional changes related to FIRMWARE attribute are required to be done after importing that VM template into your OpenNebula installation if you are using OpenNebula version 6.10.
 short_description: Windows VM template with a set of files and optimal settings.
 tags:
 - windows

--- a/appliances/default/all/6ea507ea-f894-423a-ad40-8c6b33c7ed60.yaml
+++ b/appliances/default/all/6ea507ea-f894-423a-ad40-8c6b33c7ed60.yaml
@@ -1,0 +1,81 @@
+---
+name: Windows VM Template
+version: 7.0.0-0-20250926
+publisher: OpenNebula Systems
+description: |-
+  Windows VM Template skeleton with a set of the following files and recommended settings for Windows VM:
+    - empty disk (to be used either for Windows installation or to be replaced with already pre-installed Windows OS if you already has such one,
+    - virtio-win.iso (an image file containing paravirtualized drivers required for optimal performance of Windows VMs on virtualization platforms such as KVM and some other hypervisors),
+    - one-context.iso (an image file containing OpenNebula [contextualization package](https://docs.opennebula.io/stable/product/virtual_machines_operation/guest_operating_systems/kvm_contextualization/).
+
+  This VM template should be imported into your OpenNebula cloud. After that depending on your requirements
+  1) a Windows Installation ISO image needs to be added to that template to be used for Windows installation on the empty image or
+  2) the empty disk has to be replace with already pre-installed Windows OS disk.
+
+  That VM template also contains optimal settings for Windows VMs.
+
+  **Note**: Remember to update the template in order to add a network after importing it.
+short_description: Windows VM template with a set of files and optimal settings.
+tags:
+- windows
+type: 'VMTEMPLATE'
+creation_time: 1758884727
+hypervisor: KVM
+os-id: none
+os-arch: x86_64
+format: qcow2
+opennebula_version: 6.0, 6.2, 6.4, 6.6, 6.8, 6.10, 7.0
+disks:
+  - 'Empty disk'
+  - 'Windows VirtIO Drivers'
+  - 'Contextualization Packages'
+opennebula_template:
+  context:
+    network: 'YES'
+    ssh_public_key: '$USER[SSH_PUBLIC_KEY]'
+  cpu: '1'
+  cpu_model:
+    model: 'host-passthrough'
+  graphics:
+    listen: 0.0.0.0
+    type: vnc
+  memory: '2048'
+  os:
+    arch: x86_64
+    machine: 'q35'
+  features:
+    ACPI: 'Yes'
+    apic: 'Yes'
+    guest_agent: 'Yes'
+    hyperv: 'Yes'
+    localtime: 'Yes'
+    pae: 'Yes'
+    virtio_blk_queues: 'auto'
+    virtio_scsi_queues: 'auto'
+  raw:
+    data: |-
+      <features>
+        <hyperv>
+          <evmcs state='off'/>
+          <frequencies state='on'/>
+          <ipi state='on'/>
+          <reenlightenment state='off'/>
+          <relaxed state='on'/>
+          <reset state='off'/>
+          <runtime state='on'/>
+          <spinlocks state='on' retries='8191'/>
+          <stimer state='on'/>
+          <synic state='on'/>
+          <tlbflush state='on'/>
+          <vapic state='on'/>
+          <vpindex state='on'/>
+        </hyperv>
+      </features>
+        <clock offset='utc'>
+          <timer name='hpet' present='no'/>
+          <timer name='hypervclock' present='yes'/>
+          <timer name='pit' tickpolicy='delay'/>
+          <timer name='rtc' tickpolicy='catchup'/>
+        </clock>
+    validate: 'Yes'
+images: []


### PR DESCRIPTION
 Windows VM Template skeleton with a set of the following files and recommended settings for Windows VM:
   * empty disk (to be used either for Windows installation or to be replaced with already pre-installed Windows OS if you already has such one),
   * virtio-win.iso (an image file containing paravirtualized drivers required for optimal performance of Windows VMs on virtualization platforms such as KVM and some other hypervisors),
   * one-context.iso (an image file containing OpenNebula [contextualization package](https://docs.opennebula.io/stable/product/virtual_machines_operation/guest_operating_systems/kvm_contextualization/)).

  This VM template should be imported into customer/prospect/user OpenNebula cloud. After that depending on their requirements:
  1) a Windows Installation ISO image needs to be added to that template to be used for Windows installation on the empty image or
  2) the empty disk has to be replaced with one which already has pre-installed Windows OS.

  That VM template also contains optimal settings for Windows VMs.

  **Note**: Remember to update the template in order to add a network after importing it.

  **Warning**: Some additional changes related to FIRMWARE attribute are required to be done after importing that VM template into your OpenNebula installation if you are using OpenNebula version 6.10.
