### PR TITLE
F OpenNebula/one-apps#276: Add new Win Virtio ISO

### DIFF
--- a/appliances/default/iso/1d48dcb2-12e9-4ef2-b9ba-a9b278917efb.yaml
+++ b/appliances/default/iso/1d48dcb2-12e9-4ef2-b9ba-a9b278917efb.yaml
@@ -20,5 +20,5 @@ images:
   driver: raw
   size: 789645312
   checksum:
-    md5: 9e650d0e7c6e017a91ca299c8f7ed766 
-    sha256: e14cf2b94492c3e925f0070ba7fdfedeb2048c91eea9c5a5afb30232a3976331  
+    md5: 9e650d0e7c6e017a91ca299c8f7ed766
+    sha256: e14cf2b94492c3e925f0070ba7fdfedeb2048c91eea9c5a5afb30232a3976331

--- a/appliances/default/iso/1d48dcb2-12e9-4ef2-b9ba-a9b278917efb.yaml
+++ b/appliances/default/iso/1d48dcb2-12e9-4ef2-b9ba-a9b278917efb.yaml
@@ -1,5 +1,5 @@
 ---
-name: Windows VirtIO Drivers
+name: Windows VirtIO Drivers - v0.1.285
 version: 0.1.285
 publisher: OpenNebula Systems
 description: CD-ROM image with stable VirtIO drivers for Windows.
@@ -20,5 +20,5 @@ images:
   driver: raw
   size: 789645312
   checksum:
-    md5: 9e650d0e7c6e017a91ca299c8f7ed766
-    sha256: e14cf2b94492c3e925f0070ba7fdfedeb2048c91eea9c5a5afb30232a3976331
+    md5: 9e650d0e7c6e017a91ca299c8f7ed766 
+    sha256: e14cf2b94492c3e925f0070ba7fdfedeb2048c91eea9c5a5afb30232a3976331  

--- a/appliances/default/iso/daef5b78-110a-11ea-9e3e-f0def1753696.yaml
+++ b/appliances/default/iso/daef5b78-110a-11ea-9e3e-f0def1753696.yaml
@@ -1,5 +1,5 @@
 ---
-name: Windows VirtIO Drivers
+name: Windows VirtIO Drivers - v0.1.240
 version: 0.1.240
 publisher: OpenNebula Systems
 description: CD-ROM image with stable VirtIO drivers for Windows.


### PR DESCRIPTION
Added new Win Virtio ISO v0.1.285. Due to that bug https://github.com/OpenNebula/one/issues/7269 it was needed to add Virtio version into the previous virtio appliance.